### PR TITLE
Tighten AdvWebView WebView posture

### DIFF
--- a/app/src/main/java/org/softeg/slartus/forpdaplus/classes/AdvWebView.java
+++ b/app/src/main/java/org/softeg/slartus/forpdaplus/classes/AdvWebView.java
@@ -58,8 +58,12 @@ public class AdvWebView extends WebView {
     private void init() {
         // gd = new GestureDetector(context, sogl);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            // даём разрешение подгружать несекьюрные ресурсы из assets
-            getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+            // даём разрешение подгружать несекьюрные ресурсы из assets.
+            // COMPATIBILITY_MODE keeps passive sub-resources (images,
+            // fonts) loading on https forum pages while blocking active
+            // mixed content like remote scripts. ALWAYS_ALLOW is the
+            // strictly less safe option in the WebSettings javadoc.
+            getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         }
         getSettings().setJavaScriptEnabled(true);
 
@@ -68,8 +72,13 @@ public class AdvWebView extends WebView {
         getSettings().setDomStorageEnabled(true);
         getSettings().setAllowFileAccess(true);
         getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-        getSettings().setAllowFileAccessFromFileURLs(true); //Maybe you don't need this rule
-        getSettings().setAllowUniversalAccessFromFileURLs(true);
+        // setAllowFileAccessFromFileURLs / setAllowUniversalAccessFromFileURLs
+        // only take effect when the WebView is rendering a file:// document.
+        // AdvWebView loads its HTML with loadDataWithBaseURL on an https
+        // forum base URL and references bundled resources via
+        // file:///android_asset/, which is permitted regardless. The two
+        // flags are not needed for any of the existing WebView paths and
+        // are a known sandbox-escape vector (CWE-200) when left on.
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
             getSettings().setPluginState(WebSettings.PluginState.ON);// для воспроизведения видео


### PR DESCRIPTION
Closes #149.

`AdvWebView.init()` turns on three settings that loosen the WebView sandbox more than the forum-client actually needs:

```java
getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
...
getSettings().setAllowFileAccessFromFileURLs(true); //Maybe you don't need this rule
getSettings().setAllowUniversalAccessFromFileURLs(true);
```

The HTML rendered into `AdvWebView` is always built locally by `HtmlBuilder`, `TopicBodyBuilder` or `QmsHtmlBuilder`. The page is either pointed at an `https://forum-host/forum/` base URL (`BbCodesQuickView.loadDataWithBaseURL`) or references bundled resources via `file:///android_asset/`. The `android_asset` scheme is permitted regardless of the file flags, so neither `FromFileURLs` flag is load-bearing for any of the existing WebView paths. The dev comment on the first call (`Maybe you don't need this rule`) already flags the uncertainty.

### Change

1. `setMixedContentMode(MIXED_CONTENT_ALWAYS_ALLOW)` -> `setMixedContentMode(MIXED_CONTENT_COMPATIBILITY_MODE)`. `COMPATIBILITY_MODE` keeps passive sub-resources (images, fonts) loading on an https forum page while blocking active mixed content like remote scripts. This is the right default for user-generated forum content.

2. Drop `setAllowFileAccessFromFileURLs(true)` and `setAllowUniversalAccessFromFileURLs(true)`. Neither one takes effect when the main frame is an https URL, and they are CWE-200 sandbox-escape vectors when left on.

### Out of scope

`setAllowFileAccess(true)` is left in place. Removing it would need a wider audit of every fragment that builds its own `AdvWebView` (`ForumRulesFragment`, `SpecialView`, `ProfileEditFragment`, `QmsChatFragment`, `SearchPostFragment`, `PostPreviewFragment`, `ThemeFragment`, `MentionsListFragment`), so I have kept this PR to the central `AdvWebView` only.